### PR TITLE
✨ feat: Add Google Sheets API configuration and setup

### DIFF
--- a/PythonNNTest/.env.example
+++ b/PythonNNTest/.env.example
@@ -1,0 +1,5 @@
+# Google Sheets API Configuration
+GOOGLE_SHEETS_SCOPE=https://www.googleapis.com/auth/spreadsheets
+GOOGLE_SERVICE_ACCOUNT_FILE=credentials/your-service-account-file.json
+SPREADSHEET_ID=your-spreadsheet-id
+SHEET_NAME=your-sheet-name 

--- a/PythonNNTest/.gitignore
+++ b/PythonNNTest/.gitignore
@@ -1,0 +1,31 @@
+# Environment variables
+.env
+
+# Service account credentials
+credentials/
+*.json
+**/credentials/
+**/*.json
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg 

--- a/PythonNNTest/sheets.py
+++ b/PythonNNTest/sheets.py
@@ -1,0 +1,21 @@
+import os
+from dotenv import load_dotenv
+from google.oauth2.service_account import Credentials
+from googleapiclient.discovery import build
+
+# Load environment variables
+load_dotenv()
+
+# Get configuration from environment variables
+SCOPES = [os.getenv('GOOGLE_SHEETS_SCOPE')]
+SERVICE_ACCOUNT_FILE = os.path.join(os.path.dirname(__file__), os.getenv('GOOGLE_SERVICE_ACCOUNT_FILE'))
+SPREADSHEET_ID = os.getenv('SPREADSHEET_ID')
+SHEET_NAME = os.getenv('SHEET_NAME')
+
+# Set up credentials
+credentials = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+
+# Build the Sheets API
+service = build('sheets', 'v4', credentials=credentials)
+sheet = service.spreadsheets()
+


### PR DESCRIPTION
This commit introduces the necessary configuration and setup for
interacting with the Google Sheets API in the PythonNNTest project.

The changes include:

- Adding a `.env.example` file with the required environment variables
  for the Google Sheets API configuration, such as the scope, service
  account file, spreadsheet ID, and sheet name.
- Implementing the `sheets.py` module to load the environment variables,
  set up the Google Sheets API credentials, and build the Sheets API
  service.
- Adding a `.gitignore` file to exclude the `.env` file and the
  `credentials` directory, which will contain the service account
  credentials file.

These changes will enable the project to interact with Google Sheets
and retrieve or update data as needed.